### PR TITLE
parse metadata from lambda if possible

### DIFF
--- a/components/transferForm.tsx
+++ b/components/transferForm.tsx
@@ -671,7 +671,18 @@ function ExecuteForm(
             PUSH ${typ} ${param} ;
             TRANSFER_TOKENS 
           }`;
-            props.setField(lambda, JSON.stringify(res, null, 2));
+            props.setField(
+              lambda,
+              JSON.stringify(
+                {
+                  contract_addr: props.address,
+                  mutez_amount: props.amount,
+                  payload: res,
+                },
+                null,
+                2
+              )
+            );
             props.setLoading(false);
           } catch {
             props.setLoading(false);

--- a/context/metadata.ts
+++ b/context/metadata.ts
@@ -4,7 +4,6 @@ import {
   Wallet,
 } from "@taquito/taquito";
 import { Tzip16ContractAbstraction } from "@taquito/tzip16";
-import { hex2buf } from "@taquito/utils";
 import { version } from "../types/display";
 declare const ABSTRACTION_KEY: unique symbol;
 const dispatch: { [key: string]: version } = {
@@ -12,6 +11,7 @@ const dispatch: { [key: string]: version } = {
   "0.0.8": "0.0.8",
   "0.0.9": "0.0.9",
 };
+
 async function fetchVersion(
   metadata: ContractAbstraction<ContractProvider> & {
     tzip16(

--- a/versioned/apis.ts
+++ b/versioned/apis.ts
@@ -6,7 +6,7 @@ import Version008 from "./version008";
 
 import { BigNumber } from "bignumber.js";
 import Version009 from "./version009";
-
+import { MichelsonMap } from "@taquito/taquito";
 function signers(c: contractStorage): string[] {
   return Versioned.signers(c);
 }
@@ -40,13 +40,38 @@ function toStorage(
 ): contractStorage {
   return dispatchUi[version].toContractState(c, balance);
 }
-function getProposalsId(
-  version: version,
-  c: any,
-): string {
+function getProposalsId(version: version, c: any): string {
   return dispatchUi[version].getProposalsId(c);
 }
 function toProposal(version: version, c: any): proposal {
   return dispatchUi[version].toProposal(c);
 }
-export { toStorage, signers, toProposal, VersionedApi, getProposalsId };
+function map2Object(x: any): any {
+  if (Array.isArray(x)) {
+    return x.map((x) => map2Object(x));
+  }
+  if (x instanceof MichelsonMap) {
+    return Object.fromEntries([...x.entries()]);
+  }
+  if (x instanceof BigNumber) {
+    return x.toString();
+  }
+  if (typeof x == "object" && !isNaN(Number(Object.keys(x)[0]))) {
+    return Object.entries(x).map(([_, v]) => map2Object(v));
+  }
+  if (typeof x == "object") {
+    return Object.fromEntries(
+      Object.entries(x).map(([k, v]) => [map2Object(k), map2Object(v)])
+    );
+  }
+
+  return x;
+}
+export {
+  toStorage,
+  signers,
+  toProposal,
+  VersionedApi,
+  getProposalsId,
+  map2Object,
+};

--- a/versioned/version008.ts
+++ b/versioned/version008.ts
@@ -16,7 +16,8 @@ import {
 } from "@taquito/michelson-encoder";
 import { BigNumber } from "bignumber.js";
 import { char2Bytes, bytes2Char, encodePubKey } from "@taquito/utils";
-import { map2Object } from "./apis";
+import { map2Object, matchLambda } from "./apis";
+import { connect } from "http2";
 function convert(x: string): string {
   return char2Bytes(x);
 }
@@ -139,49 +140,23 @@ class Version008 extends Versioned {
   }
   private static mapContent(content: content): proposalContent {
     if ("execute_lambda" in content) {
-      let p = new Parser();
-      let meta = {};
-      let parsed = undefined;
-      try {
-        parsed = p.parseJSON(JSON.parse(content.execute_lambda.lambda));
-      } catch {}
-      if (
-        content.execute_lambda.lambda &&
-        typeof parsed != "undefined" &&
-        Array.isArray(parsed) &&
-        parsed.length === 7
-      ) {
-        try {
-          let addr = encodePubKey(((parsed[1] as any)!.args![1] as any).bytes);
-          let typ = (parsed[2] as any).args;
-          let type = new ParameterSchema(typ![0]);
-          let payload = map2Object(type.Execute((parsed[5] as any)!.args[1]));
-          let amount = (parsed[4] as any).args[1].int;
-
-          let from_lambda = {
-            contract_address: addr,
-            mutez_amount: amount,
-            payload:
-              Object.keys(payload).length === 1 &&
-              typeof Object.values(payload)[0] == "symbol"
-                ? { [Object.keys(payload)[0]]: {} }
-                : payload,
-          };
-          meta = from_lambda;
-        } catch {}
-      }
-      let supplied;
-      try {
-        supplied = bytes2Char(content.execute_lambda.metadata!);
-      } catch {
-        supplied = JSON.stringify({ error: "Cant parse metadata" }, null, 2);
-      }
+      let meta = matchLambda({}, JSON.parse(content.execute_lambda.lambda));
       return {
         executeLambda: {
-          metadata: Object.keys(meta).length
+          metadata: !!meta
             ? JSON.stringify(meta, null, 2)
-            : supplied,
-          content: "Unable to display",
+            : JSON.stringify(
+                {
+                  status: "Cant parse lambda",
+                  meta: content.execute_lambda.metadata
+                    ? bytes2Char(content.execute_lambda.metadata)
+                    : "No meta supplied",
+                  lambda: content.execute_lambda.lambda,
+                },
+                null,
+                2
+              ),
+          content: content.execute_lambda.lambda,
         },
       };
     } else if ("transfer" in content) {

--- a/versioned/version008.ts
+++ b/versioned/version008.ts
@@ -8,12 +8,7 @@ import { contractStorage } from "../types/app";
 import { proposal, proposalContent, status } from "../types/display";
 import { ownersForm } from "./forms";
 import { Versioned } from "./interface";
-import { Parser } from "@taquito/michel-codec";
-import {
-  MichelsonMap,
-  ParameterSchema,
-  Schema,
-} from "@taquito/michelson-encoder";
+import { Parser, emitMicheline } from "@taquito/michel-codec";
 import { BigNumber } from "bignumber.js";
 import { char2Bytes, bytes2Char, encodePubKey } from "@taquito/utils";
 import { map2Object, matchLambda } from "./apis";
@@ -151,7 +146,9 @@ class Version008 extends Versioned {
                   meta: content.execute_lambda.metadata
                     ? bytes2Char(content.execute_lambda.metadata)
                     : "No meta supplied",
-                  lambda: content.execute_lambda.lambda,
+                  lambda: emitMicheline(
+                    JSON.parse(content.execute_lambda.lambda)
+                  ),
                 },
                 null,
                 2

--- a/versioned/version009.ts
+++ b/versioned/version009.ts
@@ -13,7 +13,7 @@ import { ParameterSchema } from "@taquito/michelson-encoder";
 import { MichelsonMap } from "@taquito/taquito";
 import { BigNumber } from "bignumber.js";
 import { char2Bytes, bytes2Char, encodePubKey } from "@taquito/utils";
-import { map2Object } from "./apis";
+import { map2Object, matchLambda } from "./apis";
 function convert(x: string): string {
   return char2Bytes(x);
 }
@@ -133,49 +133,34 @@ class Version009 extends Versioned {
   }
   private static mapContent(content: content): proposalContent {
     if ("execute_lambda" in content) {
-      let p = new Parser();
-      let meta = {};
-      let parsed = undefined;
-      try {
-        parsed = p.parseJSON(JSON.parse(content.execute_lambda.lambda));
-      } catch {}
-      if (
-        content.execute_lambda.lambda &&
-        typeof parsed != "undefined" &&
-        Array.isArray(parsed) &&
-        parsed.length === 7
-      ) {
-        try {
-          let addr = encodePubKey(((parsed[1] as any)!.args![1] as any).bytes);
-          let typ = (parsed[2] as any).args;
-          let type = new ParameterSchema(typ![0]);
-          let payload = map2Object(type.Execute((parsed[5] as any)!.args[1]));
-          let amount = (parsed[4] as any).args[1].int;
-
-          let from_lambda = {
-            contract_address: addr,
-            mutez_amount: amount,
-            payload:
-              Object.keys(payload).length === 1 &&
-              typeof Object.values(payload)[0] == "symbol"
-                ? { [Object.keys(payload)[0]]: {} }
-                : payload,
-          };
-          meta = from_lambda;
-        } catch {}
-      }
-      let supplied;
-      try {
-        supplied = bytes2Char(content.execute_lambda.metadata!);
-      } catch {
-        supplied = JSON.stringify({ error: "Cant parse metadata" }, null, 2);
-      }
+      let meta = matchLambda({}, JSON.parse(content.execute_lambda.lambda));
       return {
         executeLambda: {
-          metadata: Object.keys(meta).length
-            ? JSON.stringify(meta, null, 2)
-            : supplied,
-          content: "Unable to display",
+          metadata: !!content.execute_lambda.lambda
+            ? JSON.stringify(
+                !!!meta
+                  ? {
+                      status: "Cant parse lambda",
+                      meta: content.execute_lambda.metadata
+                        ? bytes2Char(content.execute_lambda.metadata)
+                        : "No meta supplied",
+                      lambda: content.execute_lambda.lambda,
+                    }
+                  : meta,
+                null,
+                2
+              )
+            : JSON.stringify(
+                {
+                  status: "Executed; lambda unavailable",
+                  meta: content.execute_lambda.metadata
+                    ? bytes2Char(content.execute_lambda.metadata)
+                    : "No meta supplied",
+                },
+                null,
+                2
+              ),
+          content: content.execute_lambda.lambda,
         },
       };
     } else if ("transfer" in content) {

--- a/versioned/version009.ts
+++ b/versioned/version009.ts
@@ -9,8 +9,11 @@ import { proposal, proposalContent, status } from "../types/display";
 import { ownersForm } from "./forms";
 import { Versioned } from "./interface";
 import { Parser } from "@taquito/michel-codec";
+import { ParameterSchema } from "@taquito/michelson-encoder";
+import { MichelsonMap } from "@taquito/taquito";
 import { BigNumber } from "bignumber.js";
-import { char2Bytes, bytes2Char } from "@taquito/utils";
+import { char2Bytes, bytes2Char, encodePubKey } from "@taquito/utils";
+import { map2Object } from "./apis";
 function convert(x: string): string {
   return char2Bytes(x);
 }
@@ -130,10 +133,48 @@ class Version009 extends Versioned {
   }
   private static mapContent(content: content): proposalContent {
     if ("execute_lambda" in content) {
+      let p = new Parser();
+      let meta = {};
+      let parsed = undefined;
+      try {
+        parsed = p.parseJSON(JSON.parse(content.execute_lambda.lambda));
+      } catch {}
+      if (
+        content.execute_lambda.lambda &&
+        typeof parsed != "undefined" &&
+        Array.isArray(parsed) &&
+        parsed.length === 7
+      ) {
+        try {
+          let addr = encodePubKey(((parsed[1] as any)!.args![1] as any).bytes);
+          let typ = (parsed[2] as any).args;
+          let type = new ParameterSchema(typ![0]);
+          let payload = map2Object(type.Execute((parsed[5] as any)!.args[1]));
+          let amount = (parsed[4] as any).args[1].int;
+
+          let from_lambda = {
+            contract_address: addr,
+            mutez_amount: amount,
+            payload:
+              Object.keys(payload).length === 1 &&
+              typeof Object.values(payload)[0] == "symbol"
+                ? { [Object.keys(payload)[0]]: {} }
+                : payload,
+          };
+          meta = from_lambda;
+        } catch {}
+      }
+      let supplied;
+      try {
+        supplied = bytes2Char(content.execute_lambda.metadata!);
+      } catch {
+        supplied = JSON.stringify({ error: "Cant parse metadata" }, null, 2);
+      }
       return {
         executeLambda: {
-            metadata: !!content.execute_lambda?.metadata
-            ? bytes2Char(content.execute_lambda.metadata) : "No metadata",
+          metadata: Object.keys(meta).length
+            ? JSON.stringify(meta, null, 2)
+            : supplied,
           content: "Unable to display",
         },
       };
@@ -161,8 +202,8 @@ class Version009 extends Versioned {
     }
   }
   static override getProposalsId(_contract: c1): string {
-    return  _contract.proposals.toString()
-   }
+    return _contract.proposals.toString();
+  }
   static override toProposal(proposal: any): proposal {
     let prop: p1 = proposal;
     const status: { [key: string]: status } = {

--- a/versioned/version009.ts
+++ b/versioned/version009.ts
@@ -9,11 +9,11 @@ import { proposal, proposalContent, status } from "../types/display";
 import { ownersForm } from "./forms";
 import { Versioned } from "./interface";
 import { Parser } from "@taquito/michel-codec";
-import { ParameterSchema } from "@taquito/michelson-encoder";
+import { emitMicheline } from "@taquito/michel-codec";
 import { MichelsonMap } from "@taquito/taquito";
 import { BigNumber } from "bignumber.js";
 import { char2Bytes, bytes2Char, encodePubKey } from "@taquito/utils";
-import { map2Object, matchLambda } from "./apis";
+import { matchLambda } from "./apis";
 function convert(x: string): string {
   return char2Bytes(x);
 }
@@ -144,7 +144,9 @@ class Version009 extends Versioned {
                       meta: content.execute_lambda.metadata
                         ? bytes2Char(content.execute_lambda.metadata)
                         : "No meta supplied",
-                      lambda: content.execute_lambda.lambda,
+                      lambda: emitMicheline(
+                        JSON.parse(content.execute_lambda.lambda)
+                      ),
                     }
                   : meta,
                 null,
@@ -160,7 +162,7 @@ class Version009 extends Versioned {
                 null,
                 2
               ),
-          content: content.execute_lambda.lambda,
+          content: JSON.parse(content.execute_lambda.lambda || ""),
         },
       };
     } else if ("transfer" in content) {


### PR DESCRIPTION
## Description
### Problem 
- Right now we allow whatever format is possible inside the metadata, so its possible to supply nonsensical metadata for the ui to display. 
### Solution 
Try parsing fields we expect from our template in lambda and generate metadata from there.
